### PR TITLE
remove duplicate wheel_zoom, add tap tool, active scroll

### DIFF
--- a/leet_topic/leet_topic.py
+++ b/leet_topic/leet_topic.py
@@ -101,7 +101,7 @@ def create_html(df, document_field, topic_field, html_filename, extra_fields=[])
         columns.append(TableColumn(field=field, title=field, width=100))
 
 
-    p1 = figure(width=500, height=500, tools="pan,wheel_zoom,lasso_select,box_zoom,box_select,reset", title="Select Here", x_range=(df.x.min(), df.x.max()), y_range=(df.y.min(), df.y.max()))
+    p1 = figure(width=500, height=500, tools="pan,tap,wheel_zoom,lasso_select,box_zoom,box_select,reset", active_scroll="wheel_zoom", title="Select Here", x_range=(df.x.min(), df.x.max()), y_range=(df.y.min(), df.y.max()))
     # p1.circle('x', 'y', source=s1, alpha=0.6)
     circle_kwargs = {"x": "x", "y": "y",
                         "size": 3,
@@ -112,7 +112,7 @@ def create_html(df, document_field, topic_field, html_filename, extra_fields=[])
     scatter = p1.circle(**circle_kwargs)
 
     s2 = ColumnDataSource(data=dict(x=[], y=[]))
-    p2 = figure(width=500, height=500, tools="pan,wheel_zoom,lasso_select,wheel_zoom, box_zoom,box_select,reset", title="Analyze Selection", x_range=(df.x.min(), df.x.max()), y_range=(df.y.min(), df.y.max()))
+    p2 = figure(width=500, height=500, tools="pan,tap,lasso_select,wheel_zoom,box_zoom,box_select,reset", active_scroll="wheel_zoom", title="Analyze Selection", x_range=(df.x.min(), df.x.max()), y_range=(df.y.min(), df.y.max()))
     # p1.circle('x', 'y', source=s1, alpha=0.6)
     circle_kwargs2 = {"x": "x", "y": "y",
                         "size": 3,


### PR DESCRIPTION
Submitting a PR for three small changes:

1.  Removing a duplicate wheel_zoom in the second plot
2. Adding the Wheel Zoom on the active scroll, meaning it's auto-selected on start up. I personally like having this auto-selected, but other people may differ.
3. Adding the Tap tool. This works pretty seamlessly with the code by just adding it in, you can tap on any point in either plot, and it will be selected. It may be of use to users. This is also auto-selected, so if you don't want this auto-selected, you can add a `active_tap=None` to the `figure(...)`.

Feel free to use or not use any of these changes.