### PR TITLE
add leet_labels column on initial s2 creation

### DIFF
--- a/leet_topic/leet_topic.py
+++ b/leet_topic/leet_topic.py
@@ -101,22 +101,18 @@ def create_html(df, document_field, topic_field, html_filename, extra_fields=[])
 
 
     p1 = figure(width=500, height=500, tools="pan,tap,wheel_zoom,lasso_select,box_zoom,box_select,reset", active_scroll="wheel_zoom", title="Select Here", x_range=(df.x.min(), df.x.max()), y_range=(df.y.min(), df.y.max()))
-    # p1.circle('x', 'y', source=s1, alpha=0.6)
     circle_kwargs = {"x": "x", "y": "y",
                         "size": 3,
                         "source": s1,
-                        # "alpha": "alpha",
                          "color": mapper
                         }
     scatter = p1.circle(**circle_kwargs)
 
-    s2 = ColumnDataSource(data=dict(x=[], y=[]))
+    s2 = ColumnDataSource(data=dict(x=[], y=[], leet_labels=[]))
     p2 = figure(width=500, height=500, tools="pan,tap,lasso_select,wheel_zoom,box_zoom,box_select,reset", active_scroll="wheel_zoom", title="Analyze Selection", x_range=(df.x.min(), df.x.max()), y_range=(df.y.min(), df.y.max()))
-    # p1.circle('x', 'y', source=s1, alpha=0.6)
     circle_kwargs2 = {"x": "x", "y": "y",
                         "size": 3,
                         "source": s2,
-                        # "alpha": "alpha",
                          "color": mapper
                         }
     scatter2 = p2.circle(**circle_kwargs2)


### PR DESCRIPTION
```
 ERROR:bokeh.core.validation.check:E-1001 (BAD_COLUMN_NAME): Glyph refers to nonexistent column name. This could either be due to a misspelling or typo, or due to an expected column being missing. : key "fill_color" value "leet_labels", key "hatch_color" value "leet_labels", key "line_color" value "leet_labels" [renderer: GlyphRenderer(id='2403', ...)]
```


I was able to resolve the error/warning being thrown. Essentially, we assign the `color` in the GlyphRenderer `scatter2` to a mapper object we create. The cmap mapper we create needs a `field_name` assigned to know from which column to assign the colors. From what I understand, Bokeh wants that `field_name` to exist in the Column Data Source (`s2`) when the mapper is assigned, so all we need to do is assign it to an empty list when its created. From some of the last lines of the code, we assign the `topic_field` (and thereby the `field_name` in the `get_color_mapping`) to "leet_labels". Let me know if this resolves the issue on your end and is also a good solution based on how things are implemented. I tested it and I don't think this affects any of the functionality of the program. I also removed some unnecessary commented out code. 