### PR TITLE
Adding Search Functionality for Topics and Documents, Topic Descriptions

### DIFF
--- a/leet_topic/leet_topic.py
+++ b/leet_topic/leet_topic.py
@@ -317,7 +317,7 @@ def create_html(df, document_field, topic_field, html_filename, topic_data, tf_i
     if tf_idf:
         col3 = column(p2, row(column(doc_search, doc_search_results), column(top_search, top_search_results)))
     else:
-        col3 = column(p2, doc_search, doc_search_results)
+        col3 = column(p2)
     app_row = row(col1, col2, col3)
     if app_name != "":
         title = Div(text=f'<h1 style="text-align: center">{app_name}</h1>')

--- a/leet_topic/leet_topic.py
+++ b/leet_topic/leet_topic.py
@@ -222,7 +222,8 @@ def create_html(df, document_field, topic_field, html_filename, topic_data, tf_i
         """)
     )
     
-    top_search.js_on_change('value', CustomJS(args=dict(topic_data=topic_data, top_search_results=top_search_results, s4=multi_choice), code="""
+    top_search.js_on_change('value', CustomJS(args=dict(topic_data=topic_data, top_search_results=top_search_results, s4=multi_choice, s1=s1), code="""
+        s1.selected.indices = []
         const search_term = cb_obj.value;
         let hits = [];
         let counter = 0;
@@ -250,6 +251,14 @@ def create_html(df, document_field, topic_field, html_filename, topic_data, tf_i
         
         top_search_results.value = data.join("\\r\\n");
         
+        let inds = [];
+        for (let i=0; i < hits.length; i++) {
+            inds.push(hits[i][0]);
+        }
+        
+        const res = [...new Set(inds)];
+        
+        s4.value = res.map(function(e){return e.toString()});
     
     """)
     )
@@ -304,9 +313,6 @@ def create_html(df, document_field, topic_field, html_filename, topic_data, tf_i
         d4.value = res.map(function(e){return e.toString()});
         s1.change.emit();
         s2.change.emit();
-
-        console.log(s1.data);
-        console.log(s1.selected.indices);
         
     
     """)


### PR DESCRIPTION
This is PR is for three main functionalities
1. Implement a string based search for topics that will populate the matching topics into the graph.
2. Implement a string based search for documents that will populate the matching documents into the graph.
3. When any topic is selected, the top words for the topic will be shown in the graph.

Some considerations and other changes: 
- It turns out that both searches require the `tf_idf` argument to be True and so if `tf_idf` is False, the searches will not appear.
- While the searches now populate the results on the graph, it's unclear how exactly they should interact with the rest of the functionality, or each other. For example, if I search for a topic and then search for a document, should it only search documents within that topic subset? Or when I select a part of the graph via select tool and then use either of the searches, should it only search over that selected subset? Currently I went with a basic functionality whereby the searches always reset and search from the original data in s1.
- It could be that we don't want to auto-populate, and maybe just give the results and a button to optionally populate.


